### PR TITLE
replace toSorted with sort equivalent (not in-place)

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -97,7 +97,7 @@ function linkPriority(module: Preload) {
 }
 
 export function sortPreloads(modules: Preload[]) {
-    return modules.toSorted((a, b) => {
+    return [...modules].sort((a, b) => {
         return linkPriority(b) - linkPriority(a);
     });
 }


### PR DESCRIPTION
Hey @wille 👋

I love what you've been working on here and have been trying to integrate it into a Vite project I'm working on. One of the first things I noted was a lack of support for Node versions pre Node v20 (I am personally using Node 18), due to the use of `toSorted`. I've proposed a small change to get `sort` on an array spread - LMK what you think!

## An aside
I noticed that you've been struggling with FOUC on dev and I know Remix were having a similar issue when they migrated to Vite. From this talk at Vitecon (https://youtu.be/mWK3Y_1kmaM?t=29878&feature=shared) it looks like they were able to get around that in a clean way. If you're interested I think the PR is https://github.com/remix-run/remix/pull/8076. 

I'm keen to explore features like partial hydration, is that something you'd be open to having in the library?