### PR TITLE
perf: memoize preload descriptors (follow-up to #6 — build them once per process)

### DIFF
--- a/src/collector.ts
+++ b/src/collector.ts
@@ -250,17 +250,87 @@ function collectModules(
         return preloads;
     }
 
-    const chunks = collectChunks(manifest, moduleId);
+    const built = getBuiltChunks(
+        manifest,
+        moduleId,
+        entry,
+        preloadFonts,
+        preloadAssets,
+        nonce,
+        asyncScript
+    );
 
-    for (const chunk of chunks.values()) {
-        if (preloads.has(chunk.file)) {
+    for (const c of built) {
+        // Skip the whole chunk if its script file is already collected — mirrors the original
+        // `if (preloads.has(chunk.file)) continue;`, which dropped that chunk's css + assets too.
+        if (preloads.has(c.file)) {
             continue;
         }
 
+        preloads.set(c.file, c.script);
+
+        for (const [cssFile, cssPreload] of c.css) {
+            if (preloads.has(cssFile)) continue;
+            preloads.set(cssFile, cssPreload);
+        }
+
+        // Assets were set unconditionally in the original (last-write-wins, no has() guard).
+        for (const [assetFile, assetPreload] of c.assets) {
+            preloads.set(assetFile, assetPreload);
+        }
+    }
+
+    return preloads;
+}
+
+/**
+ * A chunk's preload descriptors, pre-built: the `<script>` / `<link modulepreload>` descriptor
+ * plus the ordered css and asset `[href, Preload]` entries — exactly what `collectModules`
+ * would otherwise construct for one chunk on every render.
+ */
+interface BuiltChunk {
+    file: string;
+    script: Preload;
+    css: Array<[string, Preload]>;
+    assets: Array<[string, Preload]>;
+}
+
+/**
+ * Per-manifest cache of pre-built per-module descriptors, keyed by
+ * `${entry}\0${flags}\0${moduleId}`.
+ *
+ * Only used when `nonce` is empty. The `Preload` descriptor objects (and their `comment`
+ * template strings) are otherwise a pure function of
+ * `(manifest, moduleId, entry, preloadFonts, preloadAssets, asyncScript)` — all stable at
+ * runtime — so the closure-memo (`collectChunks`) left descriptor construction as the largest
+ * remaining per-render allocation in this module. Building each module's descriptors once per
+ * process removes it. A non-empty per-request CSP `nonce` bypasses the cache and builds fresh,
+ * so cached objects never carry the wrong nonce and the cache cannot grow per request.
+ * WeakMap-keyed on the manifest object so a replaced manifest (rebuild / dev HMR) drops the
+ * stale cache.
+ *
+ * The cached `Preload` objects are SHARED across renders — callers must treat them as
+ * immutable (vite-preload only reads them in getChunks/getTags/getLinkHeader/sortPreloads).
+ */
+const descriptorCache = new WeakMap<Manifest, Map<string, BuiltChunk[]>>();
+
+function buildChunksForModule(
+    manifest: Manifest,
+    moduleId: string,
+    entry: string,
+    preloadFonts: boolean,
+    preloadAssets: boolean,
+    nonce: string,
+    asyncScript: boolean
+): BuiltChunk[] {
+    const chunks = collectChunks(manifest, moduleId);
+    const built: BuiltChunk[] = [];
+
+    for (const chunk of chunks.values()) {
         const isPolyfill = chunk.src === 'vite/legacy-polyfills';
         const isPrimaryModule = chunk.src === entry;
 
-        preloads.set(chunk.file, {
+        const script: Preload = {
             // Only the entrypoint module is used as <script module>, everything else is <link rel=modulepreload>
             rel: isPrimaryModule || isPolyfill ? 'module' : 'modulepreload',
             href: chunk.file,
@@ -270,58 +340,117 @@ function collectModules(
 
             // The polyfill chunk should not be async and it should run before the entry chunk
             asyncScript: asyncScript && !isPolyfill,
-        });
+        };
 
+        const css: Array<[string, Preload]> = [];
         for (const cssFile of chunk.css || []) {
-            if (preloads.has(cssFile)) continue;
-            preloads.set(cssFile, {
-                rel: 'stylesheet',
-                href: cssFile,
-                comment: `chunk: ${chunk.name}, isEntry: ${chunk.isEntry}`,
-                isEntry: chunk.isEntry,
-                nonce,
-            });
+            css.push([
+                cssFile,
+                {
+                    rel: 'stylesheet',
+                    href: cssFile,
+                    comment: `chunk: ${chunk.name}, isEntry: ${chunk.isEntry}`,
+                    isEntry: chunk.isEntry,
+                    nonce,
+                },
+            ]);
         }
 
-        if (!preloadFonts && !preloadAssets) {
-            continue;
-        }
+        const assets: Array<[string, Preload]> = [];
+        if (preloadFonts || preloadAssets) {
+            // Assets such as svg, png imports
+            for (const asset of chunk.assets || []) {
+                const ext = path.extname(asset).substring(1);
+                let as;
+                let mimeType;
+                let skip = false;
 
-        // Assets such as svg, png imports
-        for (const asset of chunk.assets || []) {
-            const ext = path.extname(asset).substring(1);
-            let as;
-            let mimeType;
+                switch (ext) {
+                    case 'png':
+                    case 'jpg':
+                    case 'webp':
+                    case 'svg':
+                        as = 'image';
+                        mimeType =
+                            ext === 'svg' ? 'image/svg+xml' : `image/${ext}`;
+                        if (!preloadAssets) skip = true;
+                        break;
+                    case 'woff2':
+                    case 'woff':
+                    case 'ttf':
+                        as = 'font';
+                        mimeType = `font/${ext}`;
+                        if (!preloadFonts) skip = true;
+                        break;
+                }
+                if (skip) continue;
 
-            switch (ext) {
-                case 'png':
-                case 'jpg':
-                case 'webp':
-                case 'svg':
-                    as = 'image';
-                    mimeType = ext === 'svg' ? 'image/svg+xml' : `image/${ext}`;
-                    if (preloadAssets) break;
-                    else continue;
-                case 'woff2':
-                case 'woff':
-                case 'ttf':
-                    as = 'font';
-                    mimeType = `font/${ext}`;
-                    if (preloadFonts) break;
-                    else continue;
+                assets.push([
+                    asset,
+                    {
+                        rel: 'preload',
+                        href: asset,
+                        as,
+                        type: mimeType,
+                        comment: `Asset from chunk ${chunk.name}: ${chunk.file}`,
+                    },
+                ]);
             }
-
-            preloads.set(asset, {
-                rel: 'preload',
-                href: asset,
-                as,
-                type: mimeType,
-                comment: `Asset from chunk ${chunk.name}: ${chunk.file}`,
-            });
         }
+
+        built.push({ file: chunk.file, script, css, assets });
     }
 
-    return preloads;
+    return built;
+}
+
+/**
+ * Returns the pre-built per-module chunk descriptors, memoized per process when `nonce` is
+ * empty (see {@link descriptorCache}); built fresh otherwise.
+ */
+function getBuiltChunks(
+    manifest: Manifest,
+    moduleId: string,
+    entry: string,
+    preloadFonts: boolean,
+    preloadAssets: boolean,
+    nonce: string,
+    asyncScript: boolean
+): BuiltChunk[] {
+    // A per-request nonce makes the descriptors request-specific: build fresh, never cache.
+    if (nonce) {
+        return buildChunksForModule(
+            manifest,
+            moduleId,
+            entry,
+            preloadFonts,
+            preloadAssets,
+            nonce,
+            asyncScript
+        );
+    }
+
+    let perManifest = descriptorCache.get(manifest);
+    if (!perManifest) {
+        perManifest = new Map();
+        descriptorCache.set(manifest, perManifest);
+    }
+
+    const key = `${entry}\0${preloadFonts ? 1 : 0}${preloadAssets ? 1 : 0}${asyncScript ? 1 : 0}\0${moduleId}`;
+    let built = perManifest.get(key);
+    if (!built) {
+        built = buildChunksForModule(
+            manifest,
+            moduleId,
+            entry,
+            preloadFonts,
+            preloadAssets,
+            nonce,
+            asyncScript
+        );
+        perManifest.set(key, built);
+    }
+    return built;
 }
 
 /**


### PR DESCRIPTION
Follow-up to #6 (the chunk-closure memo, now merged — thanks!). This adds the second half of the optimization: memoizing the `Preload` **descriptors** themselves.

## Summary

After #6 removed the per-render import-graph re-walk, `collectModules` still built a fresh descriptor object **and** a `comment` template string for every chunk on every render. Those are pure given `(manifest, moduleId, entry, preloadFonts, preloadAssets, asyncScript)`, so they're now built once per process and cached in a `WeakMap<manifest, …>` (same manifest-keying as #6, so a swapped manifest / dev HMR drops the cache).

**A `nonce` bypasses the cache and builds fresh** — a per-request CSP nonce is request-specific, so cached objects never carry a wrong nonce and the cache can't grow per request.

`collectModules`' control flow is unchanged (same chunk-level skip, css first-wins, asset last-wins); only object construction is memoized. The cached `Preload` objects are shared read-only (the library only reads them in `getChunks`/`getTags`/`getLinkHeader`/`sortPreloads`).

## Correctness

A 5050-case equivalence harness drives the original `createChunkCollector` and the memoized one over a **real 998-module manifest** and asserts `getChunks()` `deepStrictEqual`s, across: every module individually, cumulative-all, 50 random subsets, **non-empty-nonce (cache-bypass path)**, `preloadFonts`/`preloadAssets`/`asyncScript` combos, cache-warm-twice (cold then warm), and mixed-option key isolation — **0 mismatches**.

## Performance

Warm-cache render loop (entry + 6 lazy modules → 256 preload tags, 200k renders, production), minor GCs:

| | minor GCs |
|---|--:|
| before #6 | 1505 |
| #6 (chunk-closure memo, == current master) | 266 |
| **this PR (+ descriptor memo)** | **106** |

So ~2.5× fewer GCs on top of #6 (~14× vs the original). In a production-grade SSR A/B under load, the collector **dropped out of the heap-allocation profile entirely** (it had been a top-4 allocator, ~7 MB per 10s window).

`npm test` (tsc), `prettier --check`, `npm run build` (rollup) all clean.

## Note for apps that pass a `nonce`

If you pass a per-request CSP `nonce` to the collector but don't render it on the `<script>`/`<link>` preload tags (e.g. your CSP already authorizes same-origin assets via `'self'`), that nonce is dead weight and keeps this cache bypassed — dropping it lets the memo engage.

Happy to squash/adjust naming or style however you prefer, @wille.